### PR TITLE
Changed Quorum to allow single redis server

### DIFF
--- a/src/RedLock.php
+++ b/src/RedLock.php
@@ -18,7 +18,8 @@ class RedLock
         $this->retryDelay = $retryDelay;
         $this->retryCount = $retryCount;
 
-        $this->quorum  = count($servers) / 2 + 1;
+        $this->quorum  = min(count($servers), (count($servers) / 2 + 1));
+
     }
 
     public function lock($resource, $ttl)


### PR DESCRIPTION
I know the purpose is to have multiple Redis servers, but in the circumstance that you only have 1 server it should still work...  

Without this, it never reaches quorum because it required 1.5 servers out of 1...
