### PR TITLE
Allow subclasses to override how the token is generated.

### DIFF
--- a/src/RedLock.php
+++ b/src/RedLock.php
@@ -26,7 +26,7 @@ class RedLock
     {
         $this->initInstances();
 
-        $token = uniqid();
+        $token = $this->generateToken();
         $retry = $this->retryCount;
 
         do {
@@ -80,6 +80,10 @@ class RedLock
         foreach ($this->instances as $instance) {
             $this->unlockInstance($instance, $resource, $token);
         }
+    }
+
+    protected function generateToken() {
+        return uniqid();
     }
 
     private function initInstances()


### PR DESCRIPTION
Using `uniqid()` in high frequency environments can pose a problem because the entropy isn't very high. It didn't took my long with a few processes and low ttls to encounter duplicate values returned from `uniqid()` in **different** processes.

One optimization could be to use the second parameter for high entropy, e.g. `uniqid("", true);` but instead of hardcoding it, I felt the flexibility of being able to override how it is generated better serves the community.