### PR TITLE
getQuorum method added. The current calculation returns 3.5 with 5 serve...

### DIFF
--- a/src/RedLock.php
+++ b/src/RedLock.php
@@ -18,7 +18,7 @@ class RedLock
         $this->retryDelay = $retryDelay;
         $this->retryCount = $retryCount;
 
-        $this->quorum  = min(count($servers), (count($servers) / 2 + 1));
+        $this->quorum  = $this->getQuorum(count($servers));
 
     }
 
@@ -113,5 +113,12 @@ class RedLock
 
 
         return $instance->eval($script, [$resource, $token], 1);
+    }
+
+    private function getQuorum($serverCount) {
+        if ($serverCount == 2)
+            return 1;
+
+        return floor($serverCount/2+1);
     }
 }


### PR DESCRIPTION
...rs, so it needed 4 locks then.

Flooring the calculation gives the best results I think, with one exception, when you have only 2 servers I think at least 1 should be available. Otherwise it wouldn't be much of a failover setup.