### PR TITLE
use redis client instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To create a lock manager:
 $servers = [
     ['127.0.0.1', 6379, 0.01],
     ['127.0.0.1', 6389, 0.01],
-    ['127.0.0.1', 6399, 0.01],
+    $someRedisInstance, // you may pass an already connected \Redis instance
 ];
 
 $redLock = new RedLock($servers);

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,11 @@
         {
             "name": "Ronny Lopez",
             "email": "ronny@tangotree.io"
+        },
+        {
+            "name": "Maciej Łebkowski",
+            "email": "m.lebkowski@gmail.com",
+            "role": "contributor"
         }
     ],
     "require": {

--- a/src/RedLock.php
+++ b/src/RedLock.php
@@ -8,9 +8,14 @@ class RedLock
 
     private $quorum;
 
-    private $servers = array();
-    private $instances = array();
+    private $servers = [];
+    private $instances = [];
 
+    /**
+     * @param array|Redis[] $servers
+     * @param int           $retryDelay
+     * @param int           $retryCount
+     */
     function __construct(array $servers, $retryDelay = 200, $retryCount = 3)
     {
         $this->servers = $servers;
@@ -22,11 +27,17 @@ class RedLock
 
     }
 
+    /**
+     * @param string $resource
+     * @param int $ttl — in milliseconds
+     *
+     * @return array|bool
+     */
     public function lock($resource, $ttl)
     {
         $this->initInstances();
 
-        $token = uniqid();
+        $token = uniqid("", true);
         $retry = $this->retryCount;
 
         do {
@@ -86,21 +97,40 @@ class RedLock
     {
         if (empty($this->instances)) {
             foreach ($this->servers as $server) {
-                list($host, $port, $timeout) = $server;
-                $redis = new \Redis();
-                $redis->connect($host, $port, $timeout);
+                if ($server instanceof \Redis) {
+                    $redis = $server;
+                } else {
+                    list($host, $port, $timeout) = $server;
+                    $redis = new \Redis();
+                    $redis->connect($host, $port, $timeout);
+                }
 
                 $this->instances[] = $redis;
             }
         }
     }
 
+    /**
+     * @param Redis $instance
+     * @param string $resource
+     * @param string $token
+     * @param int $ttl
+     *
+     * @return mixed
+     */
     private function lockInstance($instance, $resource, $token, $ttl)
     {
         return $instance->set($resource, $token, ['NX', 'PX' => $ttl]);
 
     }
 
+    /**
+     * @param Redis $instance
+     * @param string $resource
+     * @param string $token
+     *
+     * @return mixed
+     */
     private function unlockInstance($instance, $resource, $token)
     {
         $script = '


### PR DESCRIPTION
You may now pass a `\Redis` instance instead of an array with server details.

also added some comments and minor changes.

