### PR TITLE
fix: lock inttval(N/2)+1  instead fo N/2+1

### DIFF
--- a/src/RedLock.php
+++ b/src/RedLock.php
@@ -18,7 +18,7 @@ class RedLock
         $this->retryDelay = $retryDelay;
         $this->retryCount = $retryCount;
 
-        $this->quorum  = min(count($servers), (count($servers) / 2 + 1));
+        $this->quorum  = min(count($servers), (intval(count($servers) / 2) + 1));
     }
 
     public function lock($resource, $ttl)


### PR DESCRIPTION
hello:
I found that the calculation of the majority is not strict. In php we should use intval(N/2)+1 instead of N/2+1, because if we have three masters the we must achieve the majority of the instances (at least 3), in fact we only need achieve the majority of the instances (at least 2). 